### PR TITLE
DS-3136 Improve unit tests and remove verbs dep [revdep skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
   - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev libnlopt-dev
+  - export flipFormat_BRANCH_NAME=DS-3136
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="tmp <- unlist(strsplit(split='[[:space:]]+', tail(out, 1))); "
   - rcode+="pos.fail <- grep('FAIL', tmp); n.fail <- as.numeric(tmp[pos.fail+1]); "

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,13 +18,11 @@ Imports:
     flipTime (>= 1.2.2),
     flipU (>= 1.0.0),
     stats,
-    utils,
-    verbs
+    utils
 Remotes:
     Displayr/flipExampleData,
     Displayr/flipFormat,
     Displayr/flipTime,
-    Displayr/flipU,
-    Displayr/verbs
+    Displayr/flipU
 RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/tests/testthat/test-asnumeric.R
+++ b/tests/testthat/test-asnumeric.R
@@ -14,28 +14,66 @@ test_that("AsNumeric",
               Q2 <- factor(bank$Overall)
               Q3 <- factor(bank$Fees)
               Q4 <- factor(bank$Fees)
-              flipU::ExpectWarning(AsNumeric(data.frame(Q2, Q3, Q4),  binary = FALSE, remove.first = TRUE), "structure")
-              verbs::First(suppressWarnings(AsNumeric(data.frame(Q2, Q3, Q4),  binary = TRUE, remove.first = TRUE)))
-              verbs::First(suppressWarnings(AsNumeric(data.frame(Q2, Q3, Q4),  binary = TRUE, remove.first = FALSE)))
-              verbs::First(suppressWarnings(AsNumeric(data.frame(Q2, Q3, Q4),  binary = FALSE, remove.first = FALSE)))
-
-
-              expect_error(suppressWarnings(AsNumeric(X$a)), NA)
-              expect_error(suppressWarnings(AsNumeric(X$b)), NA)
-              expect_error(suppressWarnings(AsNumeric(X$c)), NA)
-              expect_equal(ncol(suppressWarnings(AsNumeric(X$d, binary = TRUE, remove.first = TRUE))) + 1,
-                           ncol(suppressWarnings(AsNumeric(X$d, binary = TRUE, remove.first = FALSE))))
+              df <- data.frame(Q2, Q3, Q4)
+              expect_true(all(vapply(df, is.factor, logical(1))))
+              warn.msg <- paste0("Data has been automatically converted to numeric. Values are ",
+                                 "assigned in the order of the categories: 1, 2, 3, ...; To use ",
+                                 "alternative numeric values, transform the data prior including ",
+                                 "it in this analysis (e.g. by changing its structure). The ",
+                                 "variables Q2, Q3 and Q4 have been converted.")
+              expect_warning(output <- AsNumeric(data.frame(Q2, Q3, Q4), binary = FALSE, remove.first = TRUE),
+                             warn.msg, fixed = TRUE)
+              not.factor <- Negate(is.factor)
+              expect_true(all(vapply(output, not.factor, logical(1))))
+              expect_true(all(vapply(output, is.integer, logical(1))))
+              possible.vals <- unique(unlist(lapply(output, as.numeric)))
+              expect_setequal(unique(unlist(output)), possible.vals)
+              expect_error(output <- AsNumeric(data.frame(Q2, Q3, Q4), binary = TRUE, remove.first = TRUE),
+                           NA)
+              not.factor <- Negate(is.factor)
+              expect_true(all(vapply(output, not.factor, logical(1))))
+              checkNumericTransformation <- function(vect, vect.nam, unique.vals) {
+                  is.all.numeric <- is.numeric(as.vector(vect))
+                  unique.ok <- setequal(unique(vect), unique.vals)
+                  attr.ok <- attr(vect, "label") == sub(".", ": ", vect.nam, fixed = TRUE)
+                  is.all.numeric && unique.ok && attr.ok
+              }
+              expect_true(all(mapply(checkNumericTransformation,
+                                     output, names(output), MoreArgs = list(unique.vals <- c(NA, 0, 1)))))
+              expect_error(output <- AsNumeric(data.frame(Q2, Q3, Q4), binary = TRUE, remove.first = FALSE),
+                           NA)
+              expect_true(all(mapply(checkNumericTransformation,
+                                     output, names(output), MoreArgs = list(unique.vals <- c(NA, 0, 1)))))
+              expect_warning(output <- AsNumeric(data.frame(Q2, Q3, Q4), binary = FALSE, remove.first = FALSE),
+                             warn.msg, fixed = TRUE)
+              expect_true(all(vapply(output, not.factor, logical(1))))
+              expect_true(all(vapply(output, is.integer, logical(1))))
+              possible.vals <- unique(unlist(lapply(output, as.numeric)))
+              expect_setequal(unique(unlist(output)), c(NA, 1:7))
+              expect_error(AsNumeric(X$a), NA)
+              expect_error(AsNumeric(X$b), NA)
+              expect_error(AsNumeric(X$c), NA)
+              expect_equal(ncol(AsNumeric(X$d, binary = TRUE, remove.first = TRUE)) + 1,
+                           ncol(AsNumeric(X$d, binary = TRUE, remove.first = FALSE)))
               expect_error(AsNumeric(X$d, binary = TRUE), NA)
-              expect_error(suppressWarnings(AsNumeric(X$d, binary = FALSE)), NA)
-              expect_error(suppressWarnings(AsNumeric(X$e, binary = FALSE)), NA)
-              expect_error(suppressWarnings(AsNumeric(X$e, binary = TRUE)), NA)
+              warn.msg.without.names <- sub(" The variables Q2, Q3 and Q4 have been converted.",
+                                            "",
+                                            warn.msg)
+              expect_warning(AsNumeric(X$d, binary = FALSE), warn.msg.without.names, fixed = TRUE)
+              expect_warning(AsNumeric(X$e, binary = FALSE), warn.msg.without.names, fixed = TRUE)
+              expect_warning(AsNumeric(X$e, binary = TRUE), warn.msg.without.names, fixed = TRUE)
 
-              expect_error(suppressWarnings(AsNumeric(X, binary = FALSE)), NA)
-              expect_error(suppressWarnings(AsNumeric(X, binary = TRUE)), NA)
+              expect_warning(AsNumeric(X, binary = FALSE),
+                             paste0(warn.msg.without.names, " The variables a, d and e have been converted."),
+                             fixed = TRUE)
+              expect_warning(AsNumeric(X, binary = TRUE),
+                             paste0(warn.msg.without.names, " The variable e has been converted."),
+                             fixed = TRUE)
               # Checking that names are not changed.
               xz = data.frame(Q2, Q3, Q4)
               rownames(xz)[2] = "dog"
-              xz1 = suppressWarnings(AsNumeric(xz,  binary = FALSE, remove.first = FALSE))
+              expect_warning(xz1 <- AsNumeric(xz,  binary = FALSE, remove.first = FALSE),
+                             warn.msg, fixed = TRUE)
               expect_equal(rownames(xz)[2], rownames(xz1)[2])
 
               # Dates
@@ -44,19 +82,27 @@ test_that("AsNumeric",
               dm <- c(ds[1:5], "dog", "other random thing")
               expect_equal(range(AsNumeric(dd, binary=F)), c(946684800, 947462400))
               expect_equal(range(AsNumeric(ds, binary=F)), c(946684800, 947462400))
-              expect_equal(suppressWarnings(AsNumeric(dm, binary=F)), 1:7)
+              expect_equal(expect_warning(AsNumeric(dm, binary = FALSE),
+                                          warn.msg.without.names, fixed = TRUE),
+                           1:7)
 
               # list - checking for variable names
-              expect_error(suppressWarnings(AsNumeric(list(A = Q2, B = Q3, C = Q4),  binary = FALSE, remove.first = TRUE)), NA)
-              expect_error(suppressWarnings(AsNumeric(list(Q2, Q3, Q4),  binary = TRUE, remove.first = TRUE)), NA)
-              expect_error(suppressWarnings(AsNumeric(list(Q2, Q3, Q4),  binary = FALSE, remove.first = TRUE)), NA)
+              expect_warning(AsNumeric(list(A = Q2, B = Q3, C = Q4),  binary = FALSE, remove.first = TRUE),
+                             paste0(warn.msg.without.names, " The variables A, B and C have been converted."),
+                             fixed = TRUE)
+              expect_error(AsNumeric(list(Q2, Q3, Q4),  binary = TRUE, remove.first = TRUE), NA)
+              expect_error(AsNumeric(list(Q2, Q3, Q4),  binary = FALSE, remove.first = TRUE), NA)
 
               # character vector - check order
               cc <- sprintf("Row %d", c(1:100, 1:3))
-              expect_equal(suppressWarnings(AsNumeric(cc, binary = FALSE)), c(1:100, 1:3))
+              expect_equal(expect_warning(AsNumeric(cc, binary = FALSE),
+                                          warn.msg.without.names, fixed = TRUE),
+                           c(1:100, 1:3))
 
               attr(cc, "label") <- "lbl"
-              expect_equal(attr(suppressWarnings(AsNumeric(cc, binary = FALSE)), "label"), "lbl")
+              expect_warning(output <- AsNumeric(cc, binary = FALSE),
+                             warn.msg.without.names, fixed = TRUE)
+              expect_equal(attr(output, "label"), "lbl")
           })
 
 df <- data.frame(a = 1:3, b = c("x", "y", "z"), c = 99:101)


### PR DESCRIPTION
Unit tests for AsNumeric used verbs::First only for what seems like
an interactive viewing of the output since no expectation
statements were used on their outputs. The unit tests in this
situation have been improved by comparing the structure of the
output to the expected structure after the AsNumeric transform
The occurences of First have been removed and the dep of verbs too.
